### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/soerewijn/94c22f3c-1d03-4827-aced-b4308fdc6406/6aebc6f3-8b9c-4353-accb-43858abf9ab2/_apis/work/boardbadge/d8b18cef-6190-4655-8bcd-e656e14cb25c)](https://dev.azure.com/soerewijn/94c22f3c-1d03-4827-aced-b4308fdc6406/_boards/board/t/6aebc6f3-8b9c-4353-accb-43858abf9ab2/Microsoft.RequirementCategory)
 - 👋 Hi, I’m Jurgen Soerewijn
 - 👀 I’m an Infrastructure Architect and starting to learn al about DevOps
 - 🌱 I’m currently learning for the Microsoft Azure DevOps Expert certification


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/soerewijn/94c22f3c-1d03-4827-aced-b4308fdc6406/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.